### PR TITLE
NUM-20407:Enhance docker script to be more generic

### DIFF
--- a/UM-Dockerfiles-Centos/configure.sh
+++ b/UM-Dockerfiles-Centos/configure.sh
@@ -44,35 +44,24 @@ sed -i "s|\(.*\)=UMRealmService.log|\1=$LOG_DIR/UMRealmService.log|" $SERVER_COM
 sed -i "s|\(.*\)="\""-DLOGFILE=\(.*\)|\1="\""-DLOGFILE=$LOG_DIR/nirvana.log"\""|" $SERVER_COMMON_CONF_FILE
 # Changing the um server port number to 9000. As the port number is fixed, irrespective of copied umserver port it will be always 9000. 
 sed -i "s|\(.*\)=-DADAPTER_0=\(.*\)|\1=-DADAPTER_0=nhp://0.0.0.0:$PORT|" $SERVER_COMMON_CONF_FILE
-#Changing the JMX Exporter agent destination and it's configuration file jmx_exporter_yaml
-sed -i "s|\(.*26=-javaagent:\)\(.*jmx_prometheus_javaagent.*\)|\1$UM_HOME/lib/jmx_prometheus_javaagent.jar=0.0.0.0:$JMX_AGENT_PORT:$UM_HOME/server/$INSTANCE_NAME/bin/jmx_exporter.yaml|" $SERVER_COMMON_CONF_FILE
-#Changing the JMX Exporter agent destination and it's configuration file jmx_sag_um_exporter.yaml, uncommenting to enable the JMX agent
-sed -i "s|\(.*wrapper.java.additional.27.*\)|\wrapper.java.additional.27=-javaagent:$UM_HOME/lib/jmx_prometheus_javaagent.jar=0.0.0.0:$JMX_AGENT_PORT:$UM_HOME/server/$INSTANCE_NAME/bin/jmx_sag_um_exporter.yaml|" $SERVER_COMMON_CONF_FILE
 
-#Iterating through the Server_Common.conf, Custom_Server_Common.conf files to get the highest wrapper_java_additional index used in the files
-highest_wrapper_java_additional_index=0
-
-function get_highest_wrapper_java_additional_index() {
-  filename=$1
-  while read line
-  do
-  if [[ $line == *"wrapper.java.additional."* ]]; then
-    #get all the digits from line and extract 1st set of digits
-    digits=( $(echo $line | grep -o -E '[0-9]+') )
-    index=${digits[0]}
-    if [ ! -z $index ] && [ $index -gt $highest_wrapper_java_additional_index ]; then
-      highest_wrapper_java_additional_index=$index
-    fi
-  fi
-  done < $filename
+function get_highest_wrapper_java_property_index() {
+  filenames=$1
+  property_pattern=$2
+  highest_wrapper_java_index=`grep "$property_pattern" $filenames | grep -oP "$property_pattern\K[0-9]+" | sort -n | tail -n 1`
 }
 
-get_highest_wrapper_java_additional_index $SERVER_COMMON_CONF_FILE
-get_highest_wrapper_java_additional_index $CUSTOM_SERVER_COMMON_CONF_FILE
+#Iterating through the Server_Common.conf, Custom_Server_Common.conf files to get the highest wrapper_java_additional index used in the files
+highest_wrapper_java_index=0
+get_highest_wrapper_java_property_index "$SERVER_COMMON_CONF_FILE $CUSTOM_SERVER_COMMON_CONF_FILE" "wrapper.java.additional."
 
-((highest_wrapper_java_additional_index=$highest_wrapper_java_additional_index+1))
-echo "Adding wrapper.java.additional."$highest_wrapper_java_additional_index"=-DENABLE_JMX=true to Tanuki wrapper configuration file"
+((highest_wrapper_java_additional_index=$highest_wrapper_java_index+1))
+sed -i "s|\(.*/bin/jmx_sag_um_exporter.yaml*\)|\wrapper.java.additional.$highest_wrapper_java_additional_index=-javaagent:$UM_HOME/lib/jmx_prometheus_javaagent.jar=0.0.0.0:$JMX_AGENT_PORT:$UM_HOME/server/$INSTANCE_NAME/bin/jmx_sag_um_exporter.yaml|" $SERVER_COMMON_CONF_FILE
 
+highest_wrapper_java_index=0
+get_highest_wrapper_java_property_index "$SERVER_COMMON_CONF_FILE $CUSTOM_SERVER_COMMON_CONF_FILE" "wrapper.java.additional."
+
+((highest_wrapper_java_additional_index=$highest_wrapper_java_index+1))
 #Adding wrapper_java_additional index to enable the JMX config on start of the container
 sed -i "/bin\/jmx_sag_um_exporter.yaml/ a wrapper.java.additional.$highest_wrapper_java_additional_index=-DENABLE_JMX=true" $SERVER_COMMON_CONF_FILE
 

--- a/UM-Dockerfiles-Ubuntu/configure.sh
+++ b/UM-Dockerfiles-Ubuntu/configure.sh
@@ -44,35 +44,24 @@ sed -i "s|\(.*\)=UMRealmService.log|\1=$LOG_DIR/UMRealmService.log|" $SERVER_COM
 sed -i "s|\(.*\)="\""-DLOGFILE=\(.*\)|\1="\""-DLOGFILE=$LOG_DIR/nirvana.log"\""|" $SERVER_COMMON_CONF_FILE
 # Changing the um server port number to 9000. As the port number is fixed, irrespective of copied umserver port it will be always 9000. 
 sed -i "s|\(.*\)=-DADAPTER_0=\(.*\)|\1=-DADAPTER_0=nhp://0.0.0.0:$PORT|" $SERVER_COMMON_CONF_FILE
-#Changing the JMX Exporter agent destination and it's configuration file jmx_exporter_yaml
-sed -i "s|\(.*26=-javaagent:\)\(.*jmx_prometheus_javaagent.*\)|\1$UM_HOME/lib/jmx_prometheus_javaagent.jar=0.0.0.0:$JMX_AGENT_PORT:$UM_HOME/server/$INSTANCE_NAME/bin/jmx_exporter.yaml|" $SERVER_COMMON_CONF_FILE
-#Changing the JMX Exporter agent destination and it's configuration file jmx_sag_um_exporter.yaml, uncommenting to enable the JMX agent
-sed -i "s|\(.*wrapper.java.additional.27.*\)|\wrapper.java.additional.27=-javaagent:$UM_HOME/lib/jmx_prometheus_javaagent.jar=0.0.0.0:$JMX_AGENT_PORT:$UM_HOME/server/$INSTANCE_NAME/bin/jmx_sag_um_exporter.yaml|" $SERVER_COMMON_CONF_FILE
 
-#Iterating through the Server_Common.conf, Custom_Server_Common.conf files to get the highest wrapper_java_additional index used in the files
-highest_wrapper_java_additional_index=0
-
-function get_highest_wrapper_java_additional_index() {
-  filename=$1
-  while read line
-  do
-  if [[ $line == *"wrapper.java.additional."* ]]; then
-    #get all the digits from line and extract 1st set of digits
-    digits=( $(echo $line | grep -o -E '[0-9]+') )
-    index=${digits[0]}
-    if [ ! -z $index ] && [ $index -gt $highest_wrapper_java_additional_index ]; then
-      highest_wrapper_java_additional_index=$index
-    fi
-  fi
-  done < $filename
+function get_highest_wrapper_java_property_index() {
+  filenames=$1
+  property_pattern=$2
+  highest_wrapper_java_index=`grep "$property_pattern" $filenames | grep -oP "$property_pattern\K[0-9]+" | sort -n | tail -n 1`
 }
 
-get_highest_wrapper_java_additional_index $SERVER_COMMON_CONF_FILE
-get_highest_wrapper_java_additional_index $CUSTOM_SERVER_COMMON_CONF_FILE
+#Iterating through the Server_Common.conf, Custom_Server_Common.conf files to get the highest wrapper_java_additional index used in the files
+highest_wrapper_java_index=0
+get_highest_wrapper_java_property_index "$SERVER_COMMON_CONF_FILE $CUSTOM_SERVER_COMMON_CONF_FILE" "wrapper.java.additional."
 
-((highest_wrapper_java_additional_index=$highest_wrapper_java_additional_index+1))
-echo "Adding wrapper.java.additional."$highest_wrapper_java_additional_index"=-DENABLE_JMX=true to Tanuki wrapper configuration file"
+((highest_wrapper_java_additional_index=$highest_wrapper_java_index+1))
+sed -i "s|\(.*/bin/jmx_sag_um_exporter.yaml*\)|\wrapper.java.additional.$highest_wrapper_java_additional_index=-javaagent:$UM_HOME/lib/jmx_prometheus_javaagent.jar=0.0.0.0:$JMX_AGENT_PORT:$UM_HOME/server/$INSTANCE_NAME/bin/jmx_sag_um_exporter.yaml|" $SERVER_COMMON_CONF_FILE
 
+highest_wrapper_java_index=0
+get_highest_wrapper_java_property_index "$SERVER_COMMON_CONF_FILE $CUSTOM_SERVER_COMMON_CONF_FILE" "wrapper.java.additional."
+
+((highest_wrapper_java_additional_index=$highest_wrapper_java_index+1))
 #Adding wrapper_java_additional index to enable the JMX config on start of the container
 sed -i "/bin\/jmx_sag_um_exporter.yaml/ a wrapper.java.additional.$highest_wrapper_java_additional_index=-DENABLE_JMX=true" $SERVER_COMMON_CONF_FILE
 


### PR DESCRIPTION
Problem:Docker script was using hardcoded wrapper constant in Server_Common.conf, to enable the JMX configuration

Solution:Enhanced docker script to remove the hardcoded wrapper constant, to enable JMX configuration in Server_Common.conf file

Parent PR: https://github.softwareag.com/AIM/num_src/pull/2090